### PR TITLE
Add FEX support

### DIFF
--- a/setup_valheim_server.sh
+++ b/setup_valheim_server.sh
@@ -137,6 +137,40 @@ function install_box86_and_box64() {
     fi
 }
 
+function uninstall_box86_and_box64() {
+    if ! type box86 >/dev/null && ! type box64 >/dev/null; then
+        return
+    fi
+
+    sudo apt -y purge \
+        build-essential \
+        cmake \
+        gcc-arm-linux-gnueabihf \
+        git \
+        libc6:armhf \
+        libncurses6 \
+        libstdc++6 \
+        libpulse0
+
+    if type box86 >/dev/null; then
+        notify "Uninstalling Box86"
+        pushd ~/box86/build
+        sudo make uninstall
+        popd
+        success "Uninstalling Box86 - Done"
+    fi
+
+    if type box64 >/dev/null; then
+        notify "Uninstalling Box64"
+        pushd ~/box64/build
+        sudo make uninstall
+        popd
+        success "Uninstalling Box64 - Done"
+    fi
+
+    sudo systemctl restart systemd-binfmt
+}
+
 function install_fex_emu() {
     info "Installing FEX Emu"
 

--- a/setup_valheim_server.sh
+++ b/setup_valheim_server.sh
@@ -196,6 +196,19 @@ function install_fex_emu() {
     success "Installing FEX Emu - Done"
 }
 
+function uninstall_fex_emu() {
+    if type FEXInterpreter >/dev/null; then
+        sudo apt purge -y \
+            fex-emu-armv8.0 \
+            fex-emu-binfmt32 \
+            fex-emu-binfmt64
+
+        sudo add-apt-repository -y --remove ppa:fex-emu/fex
+
+        sudo systemctl restart systemd-binfmt
+    fi
+}
+
 function install_steamcmd() {
     if [[ ! -f ~/steamcmd/steamcmd.sh ]]; then
         info "Fetching steamcmd"

--- a/setup_valheim_server.sh
+++ b/setup_valheim_server.sh
@@ -140,10 +140,6 @@ function install_box86_and_box64() {
 }
 
 function uninstall_box86_and_box64() {
-    if ! type box86 >/dev/null && ! type box64 >/dev/null; then
-        return
-    fi
-
     if type box86 >/dev/null; then
         notify "Uninstalling Box86"
         pushd ~/box86/build

--- a/setup_valheim_server.sh
+++ b/setup_valheim_server.sh
@@ -80,6 +80,8 @@ function initial_setup() {
 }
 
 function install_box86_and_box64() {
+    uninstall_fex_emu
+
     info "Installing required packages"
     sudo apt -y install \
         build-essential \
@@ -198,6 +200,7 @@ function install_fex_emu() {
 
 function uninstall_fex_emu() {
     if type FEXInterpreter >/dev/null; then
+        notify "Uninstalling FEX"
         sudo apt purge -y \
             fex-emu-armv8.0 \
             fex-emu-binfmt32 \
@@ -206,6 +209,7 @@ function uninstall_fex_emu() {
         sudo add-apt-repository -y --remove ppa:fex-emu/fex
 
         sudo systemctl restart systemd-binfmt
+        success "Uninstalling FEX - Done"
     fi
 }
 

--- a/setup_valheim_server.sh
+++ b/setup_valheim_server.sh
@@ -137,6 +137,26 @@ function install_box86_and_box64() {
     fi
 }
 
+function install_fex_emu() {
+    info "Installing FEX Emu"
+
+    sudo add-apt-repository -y ppa:fex-emu/fex
+    sudo apt update
+
+    sudo apt install -y \
+        fex-emu-armv8.0 \
+        fex-emu-binfmt32 \
+        fex-emu-binfmt64
+
+    notify "Creating RootFS, this might take a while"
+    FEXRootFSFetcher \
+        --assume-yes \
+        --extract
+    success "Creating RootFS - Done"
+
+    success "Installing FEX Emu - Done"
+}
+
 function install_steamcmd() {
     if [[ ! -f ~/steamcmd/steamcmd.sh ]]; then
         info "Fetching steamcmd"

--- a/setup_valheim_server.sh
+++ b/setup_valheim_server.sh
@@ -148,11 +148,14 @@ function install_fex_emu() {
         fex-emu-binfmt32 \
         fex-emu-binfmt64
 
-    notify "Creating RootFS, this might take a while"
-    FEXRootFSFetcher \
-        --assume-yes \
-        --extract
-    success "Creating RootFS - Done"
+    if [[ ! -d ~/.fex-emu/RootFS/${NAME}_${VERSION_ID/\./_} ]]; then
+        notify "Creating RootFS, this might take a while"
+        FEXRootFSFetcher \
+            --force-ui=tty \
+            --assume-yes \
+            --extract
+        success "Creating RootFS - Done"
+    fi
 
     success "Installing FEX Emu - Done"
 }

--- a/setup_valheim_server.sh
+++ b/setup_valheim_server.sh
@@ -172,6 +172,8 @@ function uninstall_box86_and_box64() {
 }
 
 function install_fex_emu() {
+    uninstall_box86_and_box64
+
     info "Installing FEX Emu"
 
     sudo add-apt-repository -y ppa:fex-emu/fex

--- a/setup_valheim_server.sh
+++ b/setup_valheim_server.sh
@@ -479,8 +479,12 @@ function main {
     # Update and upgrade the system
     initial_setup
 
-    # Prepare box86 and box64
-    install_box86_and_box64
+    # Prepare x86_64 emulation
+    if [[ -n $USE_FEX ]]; then
+        install_fex_emu
+    else
+        install_box86_and_box64
+    fi
 
     # Fetch and initialize steamcmd
     install_steamcmd

--- a/setup_valheim_server.sh
+++ b/setup_valheim_server.sh
@@ -144,16 +144,6 @@ function uninstall_box86_and_box64() {
         return
     fi
 
-    sudo apt -y purge \
-        build-essential \
-        cmake \
-        gcc-arm-linux-gnueabihf \
-        git \
-        libc6:armhf \
-        libncurses6 \
-        libstdc++6 \
-        libpulse0
-
     if type box86 >/dev/null; then
         notify "Uninstalling Box86"
         pushd ~/box86/build


### PR DESCRIPTION
The following PR adds support for using [FEX](https://github.com/FEX-Emu/FEX) instead of [Box86](https://github.com/ptitSeb/box86) / [Box64](https://github.com/ptitSeb/box64) for x86_64 emulation.

When enabling the use of FEX, the setup script will disable Box86 and Box64 if it already installed using the previous versions the installer.

FEX support can be enabled by using the `USE_FEX=true` environment variable when running the installer.
The full command will be `USE_FEX=true bash ./setup_valheim_server.sh`

After a testing period Box86/Box64 will be replaced with FEX unless issues pop up.