### PR TITLE
chore: replace default emulator

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -45,7 +45,7 @@ This can be done by following the first steps in [Installing the Valheim Dedicat
 ## Default x86_64 emulator
 
 The default x86_64 emulator up until now (11th Sept 2025) has been Box86 and Box64, with the Call to Arms update for Valheim I've decided to replace Box with FEX.
-This has been considered for a while as it does seem very stable and in the future should allow for using mods.
+This has been considered for a while as it does seem very stable and in the future should allow for using mods (see [Modding](#modding)).
 
 For further discussions, please do join my [Discord server](#discord).
 
@@ -278,7 +278,10 @@ Example log message:
 If this changes in the future, this section will be updated to reflect that.  
 An issue has been raised with BepInEx and can be found here [BepInEx/BepInEx#336](https://github.com/BepInEx/BepInEx/issues/336)
 
-PS: If you're willing to try to install mods on your ARM instance and are able to so successfully, please do let me know.
+As the default emulation layer has been changed to FEX, modding should now be possible.  
+If you're feeling comfortable editing the systemd service file that is currently used, you're more than welcome to, do however keep in mind that re-running the setup script does revert these changes, unless you're using overrides.
+
+If you're willing to try to install mods on your ARM instance and are able to so successfully, please do let us know in the [Discord server](#discord).
 
 As for a guide to install mods, here is one.  
 https://www.youtube.com/watch?v=h2t9cSFidt0

--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,6 @@
   - [Self-upgrade not working (14th Jan 2025 - 9th Sept 2025)](#self-upgrade-not-working-14th-jan-2025---9th-sept-2025)
   - [Default x86_64 emulator](#default-x86_64-emulator)
   - [Ubuntu version](#ubuntu-version)
-  - [Box64 configuration](#box64-configuration)
 - [Credit](#credit)
 - [Instructions](#instructions)
 - [Pre-requisite](#pre-requisite)
@@ -56,18 +55,6 @@ Currently the only supported version of Ubuntu is Ubuntu 22.04 LTS, please make 
 
 This is because changes was done in preparation to how timestamps will be handled prior to 2038.  
 This was added last minute prior to the Ubuntu 24.04LTS release cycle feature feeeze, which unfortunately impacted `armhf` which we rely on here, more information can be found at the ubuntu mailing list: https://lists.ubuntu.com/archives/ubuntu-devel-announce/2024-March/001344.html
-
-## Box64 configuration
-
-This install script has now been updated with a configuration for box64 which has been tested to work for a few weeks and by different people using this guide.  
-If you have made any changes to the `~/.box64rc` configuration file for the `[valheim_server.x86_64]` section, please remove it and run the setup script.  
-If you should experience any issues, please leave a comment.
-
-~~This script / procedure for setting up a Valheim server on ARM is currently broken as of 7th of November 2023.
-(https://www.valheimgame.com/news/patch-0-217-28/)~~
-
-~~This unfortunately also includes the rollback procedure.
-Check comments for any updates regarding this issue.~~
 
 # Credit
 

--- a/Readme.md
+++ b/Readme.md
@@ -3,6 +3,7 @@
 - [Table of Content](#table-of-content)
 - [:warning: Disclaimer :warning:](#warning-disclaimer-warning)
   - [Self-upgrade not working (14th Jan 2025 - 9th Sept 2025)](#self-upgrade-not-working-14th-jan-2025---9th-sept-2025)
+  - [Default x86_64 emulator](#default-x86_64-emulator)
   - [Ubuntu version](#ubuntu-version)
   - [Box64 configuration](#box64-configuration)
 - [Credit](#credit)
@@ -41,6 +42,13 @@ The installer self-upgrade have had a bug in it since 14th of January 2025 where
 
 If you've used the script since, prior to today (9th of September 2025), you'll have to manually upgrade the script.
 This can be done by following the first steps in [Installing the Valheim Dedicated Server](#installing-the-valheim-dedicated-server).
+
+## Default x86_64 emulator
+
+The default x86_64 emulator up until now (11th Sept 2025) has been Box86 and Box64, with the Call to Arms update for Valheim I've decided to replace Box with FEX.
+This has been considered for a while as it does seem very stable and in the future should allow for using mods.
+
+For further discussions, please do join my [Discord server](#discord).
 
 ## Ubuntu version
 

--- a/Readme.md
+++ b/Readme.md
@@ -45,7 +45,8 @@ This can be done by following the first steps in [Installing the Valheim Dedicat
 ## Default x86_64 emulator
 
 The default x86_64 emulator up until now (11th Sept 2025) has been Box86 and Box64, with the Call to Arms update for Valheim I've decided to replace Box with FEX.
-This has been considered for a while as it does seem very stable and in the future should allow for using mods (see [Modding](#modding)).
+This has been considered for a while as it does seem very stable and in the future should allow for using mods (see [Modding](#modding)).  
+It is possible to switch back to using Box by setting the `USE_BOX` environment variable.
 
 For further discussions, please do join my [Discord server](#discord).
 

--- a/setup_valheim_server.sh
+++ b/setup_valheim_server.sh
@@ -445,7 +445,7 @@ function main {
     # Stop on error
     set -e
 
-    if [[ $USE_FEX != true ]]; then
+    if [[ $USE_BOX = true ]]; then
         if [[ $NAME != 'Ubuntu' ]] || [[ $VERSION_ID != '22.04' ]]; then
             error "The release \"$PRETTY_NAME\" is not supported, please re-install using Ubuntu 22.04 LTS."
             echo "See https://github.com/husjon/valheim_server_oci_setup?tab=readme-ov-file#ubuntu-version for more information"
@@ -480,10 +480,10 @@ function main {
     # Only install Box or FEX if on ARM
     if uname -p | grep "aarch64" >/dev/null; then
         # Prepare x86_64 emulation
-        if [[ -n $USE_FEX ]]; then
-            install_fex_emu
-        else
+        if [[ -n $USE_BOX ]]; then
             install_box86_and_box64
+        else
+            install_fex_emu
         fi
     fi
 

--- a/setup_valheim_server.sh
+++ b/setup_valheim_server.sh
@@ -6,11 +6,11 @@ ORANGE=$(tput setaf 3)
 BOLD=$(tput bold)
 CLEAR=$(tput sgr0)
 
-function warn { echo -en "\n\n${BOLD}${ORANGE}[-] $* ${CLEAR}\n"; }
-function success { echo -en "${BOLD}${GREEN}[+] $* ${CLEAR}\n"; }
-function info { echo -en "\n\n${BOLD}[ ] $* ${CLEAR}\n"; }
-function error { echo -en "${BOLD}${RED}[!] $* ${CLEAR}\n"; }
-function notify { echo -en "\n\n${BOLD}${ORANGE}[!] $* ${CLEAR}\n"; }
+function warn { >&2 echo -en "\n\n${BOLD}${ORANGE}[-] $* ${CLEAR}\n"; }
+function success { >&2 echo -en "${BOLD}${GREEN}[+] $* ${CLEAR}\n"; }
+function info { >&2 echo -en "\n\n${BOLD}[ ] $* ${CLEAR}\n"; }
+function error { >&2 echo -en "${BOLD}${RED}[!] $* ${CLEAR}\n"; }
+function notify { >&2 echo -en "\n\n${BOLD}${ORANGE}[!] $* ${CLEAR}\n"; }
 
 # Gives us information about the underlying OS using systemd
 # shellcheck source=/dev/null


### PR DESCRIPTION
This PR replaced Box86/64 with FEX as previously mentioned in:
* #1
* #3 (initial support using opt-in environment variable)

Closes #1 